### PR TITLE
fix a rare race condition with activerecord cache

### DIFF
--- a/lib/copycat.rb
+++ b/lib/copycat.rb
@@ -9,9 +9,11 @@ module Copycat
   mattr_accessor :route
   mattr_accessor :everything_is_html_safe
   mattr_accessor :staging_server_endpoint
+  mattr_accessor :silence_warnings
 
   @@route = 'copycat_translations'
   @@everything_is_html_safe = false
+  @@silence_warnings = true
 
   def self.setup
     yield self

--- a/lib/copycat/implementation.rb
+++ b/lib/copycat/implementation.rb
@@ -11,7 +11,13 @@ module Copycat
 
       value = super(locale, key, scope, options)
       if value.is_a?(String) || value.nil?
-        CopycatTranslation.create(locale: locale.to_s, key: scoped_key, value: value)
+        begin
+          CopycatTranslation.create(locale: locale.to_s, key: scoped_key, value: value)
+        rescue
+          unless Copycat.silence_warnings == true
+            warn("The key #{scoped_key} could not be created in the database.")
+          end
+        end
       end
       value
     end


### PR DESCRIPTION
## the issue

in some cases, there is a race condition between checking if a key
already exists in the database and inserting that key.
When this happens, the database adapter throw an exception
because it tries to insert a key that already exists
## the fix

it rescue from the exception and throw a simple warning.
it also introduce a "silence_warnings" configuration for Copycat.
